### PR TITLE
Add weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'cargo'
+    directory: '/src-tauri'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary
- enable weekly Dependabot checks for npm dependencies
- add Dependabot configuration for the repo root