### PR TITLE
Fix router head style rendering

### DIFF
--- a/src/components/router-head/router-head.tsx
+++ b/src/components/router-head/router-head.tsx
@@ -25,12 +25,9 @@ export const RouterHead = component$(() => {
       ))}
 
       {head.styles.map((s) => {
-        const styleProps = { ...(s.props || {}) }
-        if ('dangerouslySetInnerHTML' in styleProps) {
-          delete styleProps.dangerouslySetInnerHTML
-        }
+        const styleProps = { ...(s.props || {}), dangerouslySetInnerHTML: s.style }
 
-        return <style key={s.key} {...styleProps} dangerouslySetInnerHTML={s.style} />
+        return <style key={s.key} {...styleProps} />
       })}
     </>
   )


### PR DESCRIPTION
## Summary
- avoid duplicate dangerouslySetInnerHTML when rendering head styles
- fix Vite build error in router-head component