### PR TITLE
Add settings page and library maintenance

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use crate::metadata::Metadata;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
 use tauri::command;
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 use tauri::tray::TrayIconBuilder;
@@ -13,10 +17,81 @@ const TRAY_SHOW: &str = "tray_show";
 const TRAY_HIDE: &str = "tray_hide";
 const TRAY_QUIT: &str = "tray_quit";
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct AppSettings {
+    close_on_x: bool,
+    music_folder: String,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            close_on_x: false,
+            music_folder: String::new(),
+        }
+    }
+}
+
+struct AppState {
+    settings: Mutex<AppSettings>,
+}
+
+fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_local_data_dir()
+        .map(|dir| dir.join("settings.json"))
+        .map_err(|e| e.to_string())
+}
+
+fn load_settings(app: &tauri::AppHandle) -> AppSettings {
+    let path = match settings_path(app) {
+        Ok(path) => path,
+        Err(_) => return AppSettings::default(),
+    };
+
+    let Ok(data) = fs::read_to_string(path) else {
+        return AppSettings::default();
+    };
+
+    serde_json::from_str(&data).unwrap_or_default()
+}
+
+fn save_settings(app: &tauri::AppHandle, settings: &AppSettings) -> Result<(), String> {
+    let path = settings_path(app)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+
+    let data = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    fs::write(path, data).map_err(|e| e.to_string())
+}
+
 #[command]
 fn get_metadata(app_handle: tauri::AppHandle, file_path: String) -> String {
     let song_metadata = Metadata::new(&app_handle, file_path);
     serde_json::to_string(&song_metadata).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[command]
+fn get_settings(app_handle: tauri::AppHandle, state: tauri::State<AppState>) -> AppSettings {
+    let settings = state.settings.lock().map(|s| s.clone()).unwrap_or_default();
+    if settings.music_folder.is_empty() {
+        let _ = save_settings(&app_handle, &settings);
+    }
+    settings
+}
+
+#[command]
+fn set_settings(
+    app_handle: tauri::AppHandle,
+    state: tauri::State<AppState>,
+    settings: AppSettings,
+) -> Result<AppSettings, String> {
+    if let Ok(mut current) = state.settings.lock() {
+        *current = settings.clone();
+    }
+    save_settings(&app_handle, &settings)?;
+    Ok(settings)
 }
 
 fn with_main_window<F: FnOnce(&tauri::WebviewWindow)>(app: &tauri::AppHandle, f: F) {
@@ -28,6 +103,11 @@ fn with_main_window<F: FnOnce(&tauri::WebviewWindow)>(app: &tauri::AppHandle, f:
 fn main() {
     let app = tauri::Builder::default()
         .setup(|app| {
+            let settings = load_settings(&app.handle());
+            app.manage(AppState {
+                settings: Mutex::new(settings),
+            });
+
             let show = MenuItemBuilder::new("Show").id(TRAY_SHOW).build(app)?;
             let hide = MenuItemBuilder::new("Hide").id(TRAY_HIDE).build(app)?;
             let quit = MenuItemBuilder::new("Quit").id(TRAY_QUIT).build(app)?;
@@ -70,12 +150,26 @@ fn main() {
         .on_window_event(|window, event| {
             if window.label() == MAIN_WINDOW {
                 if let WindowEvent::CloseRequested { api, .. } = event {
-                    api.prevent_close();
-                    let _ = window.hide();
+                    let app_handle = window.app_handle();
+                    let close_on_x = app_handle
+                        .state::<AppState>()
+                        .settings
+                        .lock()
+                        .map(|settings| settings.close_on_x)
+                        .unwrap_or(false);
+
+                    if !close_on_x {
+                        api.prevent_close();
+                        let _ = window.hide();
+                    }
                 }
             }
         })
-        .invoke_handler(tauri::generate_handler![get_metadata])
+        .invoke_handler(tauri::generate_handler![
+            get_metadata,
+            get_settings,
+            set_settings
+        ])
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_sql::Builder::default().build())

--- a/src/App.d.ts
+++ b/src/App.d.ts
@@ -3,7 +3,9 @@ export interface Store {
   filteredSongs: Song[]
   playlist: Song[]
   searchTerm: string
-  audioDir: string
+
+  settings: Settings
+  sync: SyncState
 
   sorting:
     | 'title-desc'
@@ -59,6 +61,19 @@ export interface Store {
     currentTime: number
     duration: number
   }
+}
+
+export interface Settings {
+  closeOnX: boolean
+  musicFolder: string
+}
+
+export interface SyncState {
+  status: 'idle' | 'scanning' | 'importing' | 'error'
+  processed: number
+  total: number
+  lastRunAt: string
+  message: string
 }
 
 export interface Album {

--- a/src/components/Shared/MusicPicker.tsx
+++ b/src/components/Shared/MusicPicker.tsx
@@ -1,16 +1,9 @@
 import { $, component$, useContext, useOnWindow, useVisibleTask$ } from '@builder.io/qwik'
 import { listen } from '@tauri-apps/api/event'
-import { invoke } from '@tauri-apps/api/core'
-import { audioDir, join } from '@tauri-apps/api/path'
 import { open } from '@tauri-apps/plugin-dialog'
-import type { DirEntry } from '@tauri-apps/plugin-fs'
-import { readDir } from '@tauri-apps/plugin-fs'
-import md5 from 'md5'
 
-import type { Metadata, Song } from '~/App'
-import { LIBRARY_DB, StoreActionsContext, StoreContext } from '~/routes/layout'
-import { isAudioFile } from '~/utils/Files'
-import Database from '@tauri-apps/plugin-sql'
+import { StoreActionsContext, StoreContext } from '~/routes/layout'
+import { useLibraryScanner } from '~/hooks/useLibraryScanner'
 
 // const WINDOW_FILE_DROP = 'tauri://file-drop'
 // const WINDOW_FILE_DROP_HOVER = 'tauri://file-drop-hover'
@@ -19,97 +12,7 @@ import Database from '@tauri-apps/plugin-sql'
 export default component$(({ styles }: { styles: { button: string; icon: string } }) => {
   const store = useContext(StoreContext)
   const storeActions = useContext(StoreActionsContext)
-
-  /**
-   *
-   * If file is an accepted audio file,
-   * get metadata from backend and store it in the DB
-   *
-   */
-  const addSong = $(async (filePath: string, fileName: string, db: Database) => {
-    if (!isAudioFile(filePath)) return
-
-    const data = await invoke<string>('get_metadata', { filePath })
-    if (!data) return
-
-    const metadata = JSON.parse(data) as Metadata
-
-    const { meta_tags } = metadata
-
-    const song: Song = {
-      id: md5(filePath),
-      path: filePath,
-      file: fileName,
-      title: meta_tags.TrackTitle || '',
-      trackNumber: parseInt(meta_tags.TrackNumber) || 0,
-      side: parseInt(meta_tags.Side),
-      album: meta_tags.Album || '',
-      artist: meta_tags.Artist || '',
-      genre: meta_tags.Genre || '',
-      bpm: parseInt(meta_tags.Bpm) || 0,
-      compilation: parseInt(meta_tags.Compilation) || 0,
-      date: meta_tags.Date || '',
-      encoder: meta_tags.Encoder || '',
-      trackTotal: parseInt(meta_tags.TrackTotal) || 0,
-      codec: metadata.codec,
-      duration: metadata.duration,
-      sampleRate: metadata.sample_rate,
-      startTime: 0,
-      favorRating: 0,
-      dateAdded: new Date().toISOString(),
-      visualsPath: metadata.visual_info.image_path,
-    }
-
-    // If song exists in DB, replace it in allSongs, else add in order
-    const existingSong = (await db.select('SELECT * FROM songs WHERE id =?', [song.id])) as Song
-
-    if (existingSong) store.allSongs[store.allSongs.findIndex((s) => s.id === song.id)] = song
-    else storeActions.addSongInOrder(song)
-
-    const columns = Object.keys(song).join(', ')
-    const values = Object.values(song)
-    const placeholders = Array.from({ length: values.length }, (_, i) => `$${i + 1}`).join(', ')
-
-    const query = `INSERT INTO songs (${columns}) VALUES (${placeholders})`
-
-    await db.execute(query, values)
-  })
-
-  /**
-   *
-   * Recursively read through entries and process each entry or it's children
-   *
-   */
-  const processEntries = $(async (basePath: string, entries: DirEntry[]) => {
-    const db = await Database.load(LIBRARY_DB)
-
-    const process = async (parentPath: string, ent: DirEntry[]) => {
-      for (const entry of ent.values()) {
-        if (entry.name.startsWith('.')) continue
-        const entryPath = await join(parentPath, entry.name)
-
-        if (entry.isDirectory) {
-          const nested = await readDir(entryPath)
-          await process(entryPath, nested)
-        } else if (entry.isFile) {
-          await addSong(entryPath, entry.name, db)
-        }
-      }
-    }
-
-    await process(basePath, entries)
-    await db.close()
-  })
-
-  /**
-   *
-   * Create a tree of file entries from the selected directory
-   *
-   */
-  const addDir = $(async (folderPath: string) => {
-    const entries = await readDir(folderPath)
-    await processEntries(folderPath, entries)
-  })
+  const { scanDirectory, scanDirectories } = useLibraryScanner(store, storeActions)
 
   /**
    *
@@ -120,40 +23,29 @@ export default component$(({ styles }: { styles: { button: string; icon: string 
     const selected = await open({
       directory: true,
       multiple: true,
-      defaultPath: store.audioDir,
+      defaultPath: store.settings.musicFolder,
     })
 
     if (Array.isArray(selected)) {
       // User selected multiple directories
-      selected.forEach((dir) => addDir(dir))
+      await scanDirectories(selected, 'import')
     } else if (selected === null) {
       // User cancelled the selection
     } else {
       // User selected a single directory
-      addDir(selected)
+      await scanDirectory(selected, 'import')
     }
   })
 
   /**
    *
-   * Set audio directroy for import dialog
-   * and
    * Add listener for file drop on the app
    *
    */
   useVisibleTask$(async () => {
-    try {
-      store.audioDir = await audioDir()
-    } catch (e) {
-      console.log(e)
-    }
-
     const unlistenFileDrop = await listen('tauri://file-drop', async (event: any) => {
       if (!event.payload) return
-      for (const entry of event.payload as string[]) {
-        const dir = await readDir(entry)
-        await processEntries(entry, dir)
-      }
+      await scanDirectories(event.payload as string[], 'import')
     })
 
     return () => unlistenFileDrop()

--- a/src/components/library/index.tsx
+++ b/src/components/library/index.tsx
@@ -8,6 +8,7 @@ import { ArrowUp } from '~/components/svg/ArrowUp'
 import { StoreContext } from '../../routes/layout'
 
 const RowHeight = 30
+const StatusBarHeight = 29
 const RowStyle = 'w-full text-sm grid grid-cols-[22px_1fr_1fr_1fr_120px_120px_120px_120px_70px] text-left items-center'
 
 const ButtonConfigs = [
@@ -55,7 +56,7 @@ export default component$(() => {
     const sizeVirtualList = async () => {
       const factor = await appWindow.scaleFactor()
       const { height } = (await appWindow.innerSize()).toLogical(factor)
-      state.virtualListHeight = height - RowHeight * 2 - 28 // 2 rows (col titles + footer)
+      state.virtualListHeight = height - RowHeight * 2 - 28 - StatusBarHeight // 2 rows (col titles + footer)
       state.windowHeight = height
     }
     sizeVirtualList()

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -9,6 +9,7 @@ const Links = [
   { title: 'Artists', url: '/artists/', shortcut: 'A' },
   { title: 'Storage', url: '/storage/', shortcut: 'O' },
   { title: 'Albums', url: '/albums/', shortcut: 'M' },
+  { title: 'Settings', url: '/settings/', shortcut: 'S' },
 ]
 
 const NavItemStyles = {
@@ -47,8 +48,6 @@ export default component$(() => {
           Shortcuts
           <span class={NavItemStyles.icon}>?</span>
         </button>
-
-        <p class={NavItemStyles.button + ` text-slate-400 text-sm`}>{store.allSongs.length} songs</p>
       </nav>
 
       {store.showKeyShortcuts && <ShortcutsModal />}

--- a/src/components/status-bar.tsx
+++ b/src/components/status-bar.tsx
@@ -1,0 +1,33 @@
+import { component$, useContext } from '@builder.io/qwik'
+import { StoreContext } from '~/routes/layout'
+
+export default component$(() => {
+  const store = useContext(StoreContext)
+
+  const progressText = store.sync.total > 0 ? ` ${store.sync.processed}/${store.sync.total}` : ''
+  let statusText = ''
+
+  if (store.sync.status === 'scanning') {
+    statusText = `Scanning${progressText}`
+  } else if (store.sync.status === 'importing') {
+    statusText = `Importing${progressText}`
+  } else if (store.sync.status === 'error') {
+    statusText = store.sync.message || 'Sync error'
+  } else if (store.sync.lastRunAt) {
+    statusText = `Last scan ${new Date(store.sync.lastRunAt).toLocaleTimeString()}`
+  } else {
+    statusText = 'Ready'
+  }
+
+  return (
+    <div
+      class="fixed top-0 left-0 right-0 z-30 border-b border-gray-700 bg-[var(--body-bg-solid)] text-xs text-gray-300"
+      style={{ height: 'var(--status-bar-height)' }}
+    >
+      <div class="flex items-center justify-between h-full px-3">
+        <span class="text-gray-400">{store.allSongs.length} songs</span>
+        <span class="text-gray-400">{statusText}</span>
+      </div>
+    </div>
+  )
+})

--- a/src/global.css
+++ b/src/global.css
@@ -18,6 +18,7 @@
   --secondary: #3f3f59;
   --navbar-width: 200px;
   --audio-sidebar-width: 250px;
+  --status-bar-height: 29px;
   --body-bg: rgba(23, 23, 31, 0.95);
   --body-bg-solid: rgb(23, 23, 31);
   --modal-background: rgba(0, 0, 0, 0.5);

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -42,6 +42,7 @@ export const KeyboardCommands = [
       { key: '⇧ O', command: 'Storage' },
       // { key: '⇧ P', command: 'Playlists' },
       { key: '⇧ M', command: 'Albums' },
+      { key: '⇧ S', command: 'Settings' },
     ],
   },
 
@@ -172,6 +173,9 @@ export function useKeyboardShortcuts(store: Store, storeActions: StoreActions) {
 
       // Navigate to Albums Page
       if (key === 'M') nav('/albums')
+
+      // Navigate to Settings Page
+      if (key === 'S') nav('/settings')
 
       /**
        *

--- a/src/hooks/useLibraryScanner.ts
+++ b/src/hooks/useLibraryScanner.ts
@@ -1,0 +1,168 @@
+import { $ } from '@builder.io/qwik'
+import { invoke } from '@tauri-apps/api/core'
+import { join } from '@tauri-apps/api/path'
+import type { DirEntry } from '@tauri-apps/plugin-fs'
+import { readDir } from '@tauri-apps/plugin-fs'
+import md5 from 'md5'
+
+import type { Metadata, Song, Store, StoreActions } from '~/App'
+import { LIBRARY_DB } from '~/routes/layout'
+import { isAudioFile } from '~/utils/Files'
+import Database from '@tauri-apps/plugin-sql'
+
+export type ScanMode = 'scan' | 'import'
+
+export function useLibraryScanner(store: Store, storeActions: StoreActions) {
+  const startSync = $((mode: ScanMode) => {
+    store.sync.status = mode === 'import' ? 'importing' : 'scanning'
+    store.sync.processed = 0
+    store.sync.total = 0
+    store.sync.message = ''
+  })
+
+  const finishSync = $(() => {
+    store.sync.status = 'idle'
+    store.sync.lastRunAt = new Date().toISOString()
+    store.sync.message = ''
+  })
+
+  const failSync = $((message: string) => {
+    store.sync.status = 'error'
+    store.sync.message = message
+  })
+
+  const addSong = $(async (filePath: string, fileName: string, db: Database) => {
+    if (!isAudioFile(filePath)) return
+
+    store.sync.total += 1
+    const data = await invoke<string>('get_metadata', { filePath })
+    if (!data) return
+
+    let metadata: Metadata
+    try {
+      metadata = JSON.parse(data) as Metadata
+    } catch {
+      return
+    }
+
+    const { meta_tags } = metadata
+
+    const song: Song = {
+      id: md5(filePath),
+      path: filePath,
+      file: fileName,
+      title: meta_tags.TrackTitle || '',
+      trackNumber: parseInt(meta_tags.TrackNumber) || 0,
+      side: parseInt(meta_tags.Side),
+      album: meta_tags.Album || '',
+      artist: meta_tags.Artist || '',
+      genre: meta_tags.Genre || '',
+      bpm: parseInt(meta_tags.Bpm) || 0,
+      compilation: parseInt(meta_tags.Compilation) || 0,
+      date: meta_tags.Date || '',
+      encoder: meta_tags.Encoder || '',
+      trackTotal: parseInt(meta_tags.TrackTotal) || 0,
+      codec: metadata.codec,
+      duration: metadata.duration,
+      sampleRate: metadata.sample_rate,
+      startTime: 0,
+      favorRating: 0,
+      dateAdded: new Date().toISOString(),
+      visualsPath: metadata.visual_info.image_path,
+    }
+
+    const existingIndex = store.allSongs.findIndex((existing) => existing.id === song.id)
+    if (existingIndex >= 0) {
+      song.dateAdded = store.allSongs[existingIndex].dateAdded
+      store.allSongs[existingIndex] = song
+    } else {
+      storeActions.addSongInOrder(song)
+    }
+
+    const columns = Object.keys(song).join(', ')
+    const values = Object.values(song)
+    const placeholders = Array.from({ length: values.length }, (_, i) => `$${i + 1}`).join(', ')
+    const updates = Object.keys(song)
+      .filter((key) => key !== 'dateAdded')
+      .map((key) => `${key}=excluded.${key}`)
+      .concat('dateAdded=songs.dateAdded')
+      .join(', ')
+
+    const query = `INSERT INTO songs (${columns}) VALUES (${placeholders}) ON CONFLICT(id) DO UPDATE SET ${updates}`
+    await db.execute(query, values)
+
+    store.sync.processed += 1
+  })
+
+  const processEntries = $(async (basePath: string, entries: DirEntry[], db: Database) => {
+    const process = async (parentPath: string, ent: DirEntry[]) => {
+      for (const entry of ent.values()) {
+        if (entry.name.startsWith('.')) continue
+        const entryPath = await join(parentPath, entry.name)
+
+        if (entry.isDirectory) {
+          const nested = await readDir(entryPath)
+          await process(entryPath, nested)
+        } else if (entry.isFile) {
+          await addSong(entryPath, entry.name, db)
+        }
+      }
+    }
+
+    await process(basePath, entries)
+  })
+
+  const scanDirectories = $(async (paths: string[], mode: ScanMode = 'scan') => {
+    if (!paths.length) return
+    startSync(mode)
+
+    let failed = false
+    const db = await Database.load(LIBRARY_DB)
+
+    await db.execute(`CREATE TABLE IF NOT EXISTS songs (
+         id TEXT PRIMARY KEY,
+         path TEXT,
+         file TEXT,
+         title TEXT,
+         album TEXT,
+         artist TEXT,
+         genre TEXT,
+         bpm INTEGER,
+         compilation INTEGER,
+         date TEXT,
+         encoder TEXT,
+         trackTotal INTEGER,
+         trackNumber INTEGER,
+         codec TEXT,
+         duration TEXT,
+         sampleRate TEXT,
+         side INTEGER,
+         startTime INTEGER,
+         favorRating INTEGER CHECK (favorRating IN (0, 1, 2)),
+         dateAdded TEXT,
+         visualsPath TEXT
+     )`)
+
+    try {
+      for (const path of paths) {
+        const entries = await readDir(path)
+        await processEntries(path, entries, db)
+      }
+    } catch {
+      failed = true
+      failSync('Scan failed')
+    } finally {
+      await db.close()
+      if (!failed) finishSync()
+    }
+  })
+
+  const scanDirectory = $(async (path: string, mode: ScanMode = 'scan') => {
+    await scanDirectories([path], mode)
+  })
+
+  return {
+    scanDirectory,
+    scanDirectories,
+  }
+}

--- a/src/routes/albums/index.tsx
+++ b/src/routes/albums/index.tsx
@@ -20,6 +20,7 @@ interface Albums {
 }
 
 type AlbumItem = [string, Album]
+const StatusBarHeight = 29
 
 export default component$(() => {
   const store = useContext(StoreContext)
@@ -40,7 +41,7 @@ export default component$(() => {
     const sizeVirtualList = async () => {
       const factor = await appWindow.scaleFactor()
       const { height } = (await appWindow.innerSize()).toLogical(factor)
-      state.virtualListHeight = height - 29 - 29 - 30 - 16 // 29 for search and filters, 20 for app bar, 16 for top padding
+      state.virtualListHeight = height - 29 - 29 - 30 - 16 - StatusBarHeight // 29 for search and filters, 20 for app bar, 16 for top padding
       state.windowHeight = height
     }
     sizeVirtualList()

--- a/src/routes/artists/index.tsx
+++ b/src/routes/artists/index.tsx
@@ -8,6 +8,7 @@ import { ArrowUp } from '~/components/svg/ArrowUp'
 import { SoundBars } from '~/components/Shared/SoundBars'
 
 const RowHeight = 30
+const StatusBarHeight = 29
 
 export default component$(() => {
   const store = useContext(StoreContext)
@@ -67,7 +68,7 @@ export default component$(() => {
     const sizeVirtualList = async () => {
       const factor = await appWindow.scaleFactor()
       const { height } = (await appWindow.innerSize()).toLogical(factor)
-      state.virtualListHeight = height - RowHeight * 2 - 28 // 2 rows (col titles + footer)
+      state.virtualListHeight = height - RowHeight * 2 - 28 - StatusBarHeight // 2 rows (col titles + footer)
       state.windowHeight = height
     }
     sizeVirtualList()

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,0 +1,248 @@
+import { $, component$, useContext, useStore } from '@builder.io/qwik'
+import { invoke } from '@tauri-apps/api/core'
+import { audioDir } from '@tauri-apps/api/path'
+import { open } from '@tauri-apps/plugin-dialog'
+import { exists } from '@tauri-apps/plugin-fs'
+import Database from '@tauri-apps/plugin-sql'
+
+import type { Settings } from '~/App'
+import { useLibraryScanner } from '~/hooks/useLibraryScanner'
+import { organizeFiles } from '~/utils/Files'
+import { LIBRARY_DB, StoreActionsContext, StoreContext } from '../layout'
+
+const SectionClass = 'border border-gray-700 rounded p-4 flex flex-col gap-3 bg-[rgba(0,0,0,.1)]'
+const ButtonClass = 'px-3 py-2 text-sm rounded border border-gray-700 hover:border-gray-500 transition'
+
+export default component$(() => {
+  const store = useContext(StoreContext)
+  const storeActions = useContext(StoreActionsContext)
+  const scanner = useLibraryScanner(store, storeActions)
+  const cleanupStatus = useStore({ running: false, removed: 0, confirmAction: '' as '' | 'missing' | 'clear' })
+
+  const saveSettings = $(async (next: Settings) => {
+    store.settings = next
+    await invoke('set_settings', {
+      settings: {
+        close_on_x: next.closeOnX,
+        music_folder: next.musicFolder,
+      },
+    })
+  })
+
+  const toggleCloseOnX = $(async () => {
+    await saveSettings({ ...store.settings, closeOnX: !store.settings.closeOnX })
+  })
+
+  const changeFolder = $(async () => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      defaultPath: store.settings.musicFolder || undefined,
+    })
+
+    if (!selected || Array.isArray(selected)) return
+    await saveSettings({ ...store.settings, musicFolder: selected })
+  })
+
+  const resetFolder = $(async () => {
+    const defaultPath = await audioDir()
+    await saveSettings({ ...store.settings, musicFolder: defaultPath })
+  })
+
+  const scanNow = $(async () => {
+    if (!store.settings.musicFolder) return
+    await scanner.scanDirectories([store.settings.musicFolder], 'scan')
+  })
+
+  const clearLibrary = $(async () => {
+    const db = await Database.load(LIBRARY_DB)
+    await db.execute('DELETE FROM songs')
+    await db.close()
+
+    store.allSongs = []
+    store.filteredSongs = []
+    store.playlist = []
+    store.queue = []
+    store.libraryView.cursorIdx = 0
+    store.storageView.rootFile = organizeFiles([])
+    store.storageView.pathIndexMap = {}
+    store.storageView.nodeCount = 0
+
+    if (store.player.audioElem) {
+      store.player.audioElem.pause()
+      store.player.audioElem.src = ''
+      store.player.audioElem.load()
+    }
+
+    store.player.currSong = undefined
+    store.player.currSongIndex = 0
+    store.player.currentTime = 0
+    store.player.duration = 0
+    store.player.isPaused = true
+    cleanupStatus.confirmAction = ''
+  })
+
+  const removeMissingFiles = $(async () => {
+    cleanupStatus.running = true
+    cleanupStatus.removed = 0
+    store.sync.status = 'scanning'
+    store.sync.processed = 0
+    store.sync.total = store.allSongs.length
+    store.sync.message = 'Checking files'
+
+    const missingIds: string[] = []
+    for (const song of store.allSongs) {
+      try {
+        const isPresent = await exists(song.path)
+        if (!isPresent) missingIds.push(song.id)
+      } catch {
+        missingIds.push(song.id)
+      }
+      store.sync.processed += 1
+      if (store.sync.processed % 10 === 0) {
+        await new Promise((resolve) => requestAnimationFrame(resolve))
+      }
+    }
+
+    if (missingIds.length) {
+      cleanupStatus.removed = missingIds.length
+      const db = await Database.load(LIBRARY_DB)
+      for (let i = 0; i < missingIds.length; i += 200) {
+        const chunk = missingIds.slice(i, i + 200)
+        const placeholders = chunk.map((_, index) => `$${index + 1}`).join(', ')
+        await db.execute(`DELETE FROM songs WHERE id IN (${placeholders})`, chunk)
+      }
+      await db.close()
+
+      const missingSet = new Set(missingIds)
+      store.allSongs = store.allSongs.filter((song) => !missingSet.has(song.id))
+      store.filteredSongs = store.filteredSongs.filter((song) => !missingSet.has(song.id))
+      store.playlist = store.playlist.filter((song) => !missingSet.has(song.id))
+      store.queue = store.queue.filter((song) => !missingSet.has(song.id))
+      store.libraryView.cursorIdx = Math.min(store.libraryView.cursorIdx, store.filteredSongs.length - 1)
+      if (store.libraryView.cursorIdx < 0) store.libraryView.cursorIdx = 0
+
+      if (store.player.currSong && missingSet.has(store.player.currSong.id)) {
+        if (store.player.audioElem) {
+          store.player.audioElem.pause()
+          store.player.audioElem.src = ''
+          store.player.audioElem.load()
+        }
+        store.player.currSong = undefined
+        store.player.currSongIndex = 0
+        store.player.currentTime = 0
+        store.player.duration = 0
+        store.player.isPaused = true
+      }
+    }
+
+    store.sync.status = 'idle'
+    store.sync.message = ''
+    store.sync.lastRunAt = new Date().toISOString()
+    cleanupStatus.running = false
+    cleanupStatus.confirmAction = ''
+  })
+
+  return (
+    <section class="w-full flex-1 p-6 flex flex-col gap-6">
+      <div class={SectionClass}>
+        <div class="flex items-center justify-between">
+          <div>
+            <h2 class="text-sm font-medium">Close app on X</h2>
+            <p class="text-xs text-gray-400 mt-1">Stop music and exit instead of hiding to tray.</p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={store.settings.closeOnX}
+            class={`w-12 h-6 rounded-full border transition ${
+              store.settings.closeOnX ? 'bg-emerald-500 border-emerald-400' : 'bg-gray-800 border-gray-700'
+            }`}
+            onClick$={toggleCloseOnX}
+          >
+            <span
+              class={`block w-5 h-5 rounded-full bg-white transition translate-y-[1px] ${
+                store.settings.closeOnX ? 'translate-x-[23px]' : 'translate-x-[1px]'
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+
+      <div class={SectionClass}>
+        <div>
+          <h2 class="text-sm font-medium">Default music folder</h2>
+          <p class="text-xs text-gray-400 mt-1">New music in this folder is picked up automatically.</p>
+        </div>
+        <div class="flex items-center gap-3">
+          <button class={ButtonClass} onClick$={changeFolder}>
+            Change Folder
+          </button>
+          <button class={ButtonClass} onClick$={resetFolder}>
+            Reset to Default
+          </button>
+          <button class={ButtonClass} onClick$={scanNow}>
+            Scan Now
+          </button>
+        </div>
+        <div class="text-xs text-gray-400 truncate">{store.settings.musicFolder || 'Not set'}</div>
+      </div>
+
+      <div class={SectionClass}>
+        <div>
+          <h2 class="text-sm font-medium">Clear library</h2>
+          <p class="text-xs text-gray-400 mt-1">Remove everything or clean up missing files.</p>
+        </div>
+        {(cleanupStatus.running || cleanupStatus.removed > 0) && (
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between text-xs text-gray-400">
+              <span>
+                {cleanupStatus.running
+                  ? `Checking ${store.sync.processed}/${store.sync.total}`
+                  : `Removed ${cleanupStatus.removed} missing file${cleanupStatus.removed === 1 ? '' : 's'}`}
+              </span>
+              <span>{store.sync.total > 0 ? Math.round((store.sync.processed / store.sync.total) * 100) : 0}%</span>
+            </div>
+            <progress
+              class="w-full h-2 rounded bg-gray-800 overflow-hidden border border-gray-700 [&::-webkit-progress-bar]:bg-gray-800 [&::-webkit-progress-value]:bg-emerald-400 [&::-moz-progress-bar]:bg-emerald-400"
+              value={store.sync.processed}
+              max={store.sync.total || 1}
+            />
+          </div>
+        )}
+        <div class="flex items-center gap-3">
+          {cleanupStatus.confirmAction === 'missing' ? (
+            <>
+              <button class={ButtonClass} onClick$={removeMissingFiles}>
+                Confirm Remove Missing
+              </button>
+              <button class={ButtonClass} onClick$={() => (cleanupStatus.confirmAction = '')}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button class={ButtonClass} onClick$={() => (cleanupStatus.confirmAction = 'missing')}>
+              Remove Missing Files
+            </button>
+          )}
+          {cleanupStatus.confirmAction === 'clear' ? (
+            <>
+              <button class={ButtonClass + ' text-red-300 hover:text-red-200'} onClick$={clearLibrary}>
+                Confirm Clear Library
+              </button>
+              <button class={ButtonClass} onClick$={() => (cleanupStatus.confirmAction = '')}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              class={ButtonClass + ' text-red-300 hover:text-red-200'}
+              onClick$={() => (cleanupStatus.confirmAction = 'clear')}
+            >
+              Clear Library
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+})

--- a/src/routes/storage/index.tsx
+++ b/src/routes/storage/index.tsx
@@ -10,6 +10,7 @@ import { organizeFiles } from '~/utils/Files'
 import { useStoragePage } from '~/hooks/useStoragePage'
 
 const RowHeight = 30
+const StatusBarHeight = 29
 
 export default component$(() => {
   const store = useContext(StoreContext)
@@ -31,7 +32,7 @@ export default component$(() => {
     const sizeVirtualList = async () => {
       const factor = await appWindow.scaleFactor()
       const { height } = (await appWindow.innerSize()).toLogical(factor)
-      state.virtualListHeight = height - RowHeight * 2 - 28 // 2 rows (col titles + footer)
+      state.virtualListHeight = height - RowHeight * 2 - 28 - StatusBarHeight // 2 rows (col titles + footer)
       state.windowHeight = height
     }
     sizeVirtualList()


### PR DESCRIPTION
## Summary
- add persistent app settings (close-on-X, default music folder) with Tauri-backed storage
- introduce a settings page for scanning, cleanup, and library management with inline confirmation
- add a top status bar and shared library scanner to unify import/scan updates

## Testing
- npm run lint